### PR TITLE
Fix TypeScript errors in storage and share dialog

### DIFF
--- a/client/src/components/ShareDialog.tsx
+++ b/client/src/components/ShareDialog.tsx
@@ -120,7 +120,10 @@ export function ShareDialog({ item, itemType, isOpen, onClose }: ShareDialogProp
 
   if (!item || !itemType) return null;
 
-  const itemName = "name" in item ? `${item.name}${(item as File).ext ? `.${(item as File).ext}` : ""}` : item.name;
+  const itemName =
+    itemType === "file"
+      ? `${item.name}${(item as File).ext ? `.${(item as File).ext}` : ""}`
+      : item.name;
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { pgTable, text, varchar, timestamp, integer, boolean, json, index } from "drizzle-orm/pg-core";
+import { pgTable, text, varchar, timestamp, integer, boolean, json, index, type AnyPgColumn } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
@@ -19,7 +19,7 @@ export const users = pgTable("users", {
 export const folders = pgTable("folders", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   name: text("name").notNull(),
-  parentId: varchar("parent_id").references(() => folders.id, { onDelete: "cascade" }),
+  parentId: varchar("parent_id").references((): AnyPgColumn => folders.id, { onDelete: "cascade" }),
   ownerId: varchar("owner_id").references(() => users.id, { onDelete: "cascade" }).notNull(),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),


### PR DESCRIPTION
## Summary
- Correct storage session type and returning casts
- Type self-referential folders schema safely
- Fix ShareDialog item name computation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bb958d5e248333bae66d10fd1a2cd8